### PR TITLE
docs(llm): add provider routing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository contains the official client libraries for [sunra.ai](https://su
 Before using any client library, you'll need to:
 
 1. Sign up at [sunra.ai](https://sunra.ai)
-2. Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+2. Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 3. Set your API key as an environment variable: `export SUNRA_KEY=your-api-key`
 
 ### Python Example
@@ -80,6 +80,27 @@ const result = await sunra.subscribe(
 );
 console.log(result.images[0].url);
 ```
+
+## LLM APIs
+
+Sunra's LLM endpoints are compatible with the standard OpenAI and Anthropic API formats. Use the corresponding official SDK with `https://api-llm.sunra.ai/v1` as the base URL; a separate Sunra LLM package is not required.
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.SUNRA_KEY,
+  baseURL: "https://api-llm.sunra.ai/v1",
+});
+
+const completion = await client.chat.completions.create({
+  model: "google/gemini-2.5-flash",
+  messages: [{ role: "user", content: "Hello" }],
+  provider: { only: ["google-vertexai"] },
+});
+```
+
+Omit `provider` to use automatic routing. See the [LLM documentation](https://docs.sunra.ai/llm/llm-quickstart) and the runnable Node.js and Python examples in this repository.
 
 ### Java Example
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@
 在使用任何客户端库之前，您需要：
 
 1. 在 [sunra.ai](https://sunra.ai) 注册
-2. 从 [仪表板](https://sunra.ai/dashboard/keys) 获取您的 API 密钥
+2. 从 [仪表板](https://sunra.ai/dashboard/api-tokens) 获取您的 API 密钥
 3. 将您的 API 密钥设置为环境变量：`export SUNRA_KEY=your-api-key`
 
 ### Python 示例
@@ -80,6 +80,27 @@ const result = await sunra.subscribe(
 );
 console.log(result.images[0].url);
 ```
+
+## LLM API
+
+Sunra 的 LLM 端点兼容标准 OpenAI 和 Anthropic API 格式。使用对应的官方 SDK，并将基础 URL 设置为 `https://api-llm.sunra.ai/v1`；无需安装单独的 Sunra LLM 包。
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.SUNRA_KEY,
+  baseURL: "https://api-llm.sunra.ai/v1",
+});
+
+const completion = await client.chat.completions.create({
+  model: "google/gemini-2.5-flash",
+  messages: [{ role: "user", content: "Hello" }],
+  provider: { only: ["google-vertexai"] },
+});
+```
+
+省略 `provider` 时使用自动路由。详细说明见 [LLM 文档](https://docs.sunra.ai/zh-Hans/llm/llm-quickstart)，本仓库也提供可运行的 Node.js 和 Python 示例。
 
 ### Java 示例
 
@@ -207,4 +228,3 @@ npx @sunra/mcp-server --transport http --port 3925
 - [fal-ai/fal](https://github.com/fal-ai/fal/tree/main/projects/fal_client)
 
 并已适配以与 sunra.ai 协同工作。原始项目根据 MIT/Apache 2.0 许可证授权。我们对原始作者的贡献表示感谢。
-

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -17,7 +17,7 @@ Join our [Discord community](https://discord.gg/W9F3tveq) to connect with other 
 The `SunraClient` library serves as a client for sunra.ai applications and AI models. Before using this library, you'll need to:
 
 1. Sign up at [sunra.ai](https://sunra.ai)
-2. Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+2. Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 3. Set your API key as an environment variable: `export SUNRA_KEY=your-api-key`
 
 The client is available on Maven Central. There are three different modules:

--- a/clients/java/README.zh-CN.md
+++ b/clients/java/README.zh-CN.md
@@ -17,7 +17,7 @@
 `SunraClient` 库用作 sunra.ai 应用程序和 AI 模型的客户端。在使用此库之前，您需要：
 
 1. 在 [sunra.ai](https://sunra.ai) 注册
-2. 从 [仪表板](https://sunra.ai/dashboard/keys) 获取您的 API 密钥
+2. 从 [仪表板](https://sunra.ai/dashboard/api-tokens) 获取您的 API 密钥
 3. 将您的 API 密钥设置为环境变量：`export SUNRA_KEY=your-api-key`
 
 该客户端可在 Maven Central 上获取。有三个不同的模块：

--- a/clients/javascript/README.md
+++ b/clients/javascript/README.md
@@ -17,7 +17,7 @@ Join our [Discord community](https://discord.gg/W9F3tveq) to connect with other 
 Before using the client, you'll need to:
 
 1. Sign up at [sunra.ai](https://sunra.ai)
-2. Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+2. Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 3. Set your API key as an environment variable: `export SUNRA_KEY=your-api-key`
 
 Then set up your credentials:

--- a/clients/javascript/README.zh-CN.md
+++ b/clients/javascript/README.zh-CN.md
@@ -17,7 +17,7 @@
 在使用客户端之前，您需要：
 
 1. 在 [sunra.ai](https://sunra.ai) 注册
-2. 从 [仪表板](https://sunra.ai/dashboard/keys) 获取您的 API 密钥
+2. 从 [仪表板](https://sunra.ai/dashboard/api-tokens) 获取您的 API 密钥
 3. 将您的 API 密钥设置为环境变量：`export SUNRA_KEY=your-api-key`
 
 然后设置您的凭据：

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -19,7 +19,7 @@ pip install sunra-client
 Before using the client, you'll need to:
 
 1. Sign up at [sunra.ai](https://sunra.ai)
-2. Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+2. Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 3. Set your API key as an environment variable: `export SUNRA_KEY=your-api-key` 
 
 ## Configuration

--- a/clients/python/README.zh-CN.md
+++ b/clients/python/README.zh-CN.md
@@ -19,7 +19,7 @@ pip install sunra-client
 在使用客户端之前，您需要：
 
 1. 在 [sunra.ai](https://sunra.ai) 注册
-2. 从 [仪表板](https://sunra.ai/dashboard/keys) 获取您的 API 密钥
+2. 从 [仪表板](https://sunra.ai/dashboard/api-tokens) 获取您的 API 密钥
 3. 将您的 API 密钥设置为环境变量：`export SUNRA_KEY=your-api-key` 
 
 ## 配置

--- a/examples/demo-nextjs-app-router/README.md
+++ b/examples/demo-nextjs-app-router/README.md
@@ -11,7 +11,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 First, get your API key:
 
 1. Sign up at [sunra.ai](https://sunra.ai)
-2. Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+2. Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 
 Then set up your environment variables:
 

--- a/examples/demo-nextjs-app-router/README.zh-CN.md
+++ b/examples/demo-nextjs-app-router/README.zh-CN.md
@@ -11,7 +11,7 @@
 首先，获取您的 API 密钥：
 
 1. 在 [sunra.ai](https://sunra.ai) 注册
-2. 从[仪表板](https://sunra.ai/dashboard/keys)获取您的 API 密钥
+2. 从[仪表板](https://sunra.ai/dashboard/api-tokens)获取您的 API 密钥
 
 然后设置您的环境变量：
 

--- a/examples/demo-nextjs-page-router/README.md
+++ b/examples/demo-nextjs-page-router/README.md
@@ -11,7 +11,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 First, get your API key:
 
 1. Sign up at [sunra.ai](https://sunra.ai)
-2. Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+2. Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 
 Then set up your environment variables:
 

--- a/examples/demo-nextjs-page-router/README.zh-CN.md
+++ b/examples/demo-nextjs-page-router/README.zh-CN.md
@@ -11,7 +11,7 @@
 首先，获取您的 API 密钥：
 
 1. 在 [sunra.ai](https://sunra.ai) 注册
-2. 从[仪表板](https://sunra.ai/dashboard/keys)获取您的 API 密钥
+2. 从[仪表板](https://sunra.ai/dashboard/api-tokens)获取您的 API 密钥
 
 然后设置您的环境变量：
 

--- a/examples/demo-nodejs/package.json
+++ b/examples/demo-nodejs/package.json
@@ -13,6 +13,7 @@
     "image-to-image": "tsx src/image-to-image.ts",
     "text-to-image": "tsx src/text-to-image.ts",
     "image-to-video": "tsx src/image-to-video.ts",
+    "llm": "tsx src/demo-llm.ts",
     "stream-status": "tsx src/stream-status.ts",
     "stream-subscribe": "tsx src/stream-subscribe.ts"
   },

--- a/examples/demo-nodejs/src/demo-llm.ts
+++ b/examples/demo-nodejs/src/demo-llm.ts
@@ -2,6 +2,12 @@ import OpenAI from 'openai'
 import chalk from 'chalk'
 import { setGlobalDispatcher, ProxyAgent } from 'undici'
 
+type SunraChatCompletionParams = OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+  provider?: {
+    only?: string[];
+  };
+};
+
 const apiKey = process.env.SUNRA_KEY || ''
 if (!apiKey) {
   console.error(chalk.red('SUNRA_KEY is not set'))
@@ -24,30 +30,31 @@ const main = async () => {
       setGlobalDispatcher(new ProxyAgent(proxyUrl))
     }
 
-    // Initialize OpenAI client with Sunra endpoint (now proxy-aware!)
+    // Initialize the standard OpenAI client with Sunra's compatible endpoint.
     const client = new OpenAI({
       apiKey,
-      baseURL: 'http://api-llm.sunra.ai/v1'
+      baseURL: 'https://api-llm.sunra.ai/v1',
     })
 
     console.log(chalk.green('Sending streaming chat completion request...'))
 
-    // Make a streaming chat completion request
-    const stream = await client.chat.completions.create({
-      model: 'google/gemini-2.5-flash-lite', // You can use any llm model available on Sunra
+    const request: SunraChatCompletionParams = {
+      model: 'google/gemini-2.5-flash',
+      // Omit provider to use automatic routing.
+      provider: { only: ['google-vertexai'] },
       messages: [
         {
-          'role': 'system',
-          'content': 'You are an expert in AIGC, you can help me optimize the prompt for better results, especially for text to image models. I will give you a prompt, you can help me optimize it.'
-
+          role: 'system',
+          content: 'You are a helpful assistant.',
         },
         {
           role: 'user',
-          content: 'the original prompt is: "A scene from a high-quality animated film, like a work by Makoto Shinkai. In a deep midsummer forest, a train speeds down tracks showered in sunlight filtering through the trees (komorebi). The camera weaves through the trees, chasing the train to emphasize the sense of speed. A girl with her head out the window is bathed in the rapidly changing light and shadow, her hair fluttering in a wind that carries the scent of green. The trees in the background become a green afterimage, vividly highlighting her expression, full of liberation, from moment to moment. "'
-        }
+          content: 'Explain provider routing in two short sentences.',
+        },
       ],
-      stream: true
-    })
+      stream: true,
+    }
+    const stream = await client.chat.completions.create(request)
 
     console.log(chalk.blue('\n' + '='.repeat(50)))
     console.log(chalk.blue('Streaming Response:'))
@@ -65,8 +72,6 @@ const main = async () => {
     console.log(chalk.blue('\n' + '='.repeat(50)))
     console.log(chalk.green(`Full Response: ${fullResponse}`))
     console.log(chalk.blue('='.repeat(50)))
-
-
   } catch (error) {
     const data = (error as any).response?.data
     // Check if this is an axios/fetch error with response data

--- a/examples/demo-python/README.md
+++ b/examples/demo-python/README.md
@@ -12,12 +12,12 @@ Before running any examples, make sure you have:
 
 1. Installed the sunra-client library:
    ```bash
-   pip install sunra-client
+   pip install sunra-client openai
    ```
 
 2. Get your API key:
    - Sign up at [sunra.ai](https://sunra.ai)
-   - Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+   - Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 
 3. Set your API key as an environment variable:
    ```bash
@@ -33,6 +33,7 @@ Before running any examples, make sure you have:
 - **`text-to-video.py`** - Text-to-video generation
 - **`image-to-video.py`** - Image-to-video transformation
 - **`speech-to-text.py`** - Speech-to-text conversion
+- **`demo-llm.py`** - LLM chat completion with automatic or explicit provider routing
 
 ### Transform Input Examples
 

--- a/examples/demo-python/README.zh-CN.md
+++ b/examples/demo-python/README.zh-CN.md
@@ -12,12 +12,12 @@
 
 1. 安装 sunra-client 库：
    ```bash
-   pip install sunra-client
+   pip install sunra-client openai
    ```
 
 2. 获取您的 API 密钥：
    - 在 [sunra.ai](https://sunra.ai) 注册
-   - 从[仪表板](https://sunra.ai/dashboard/keys)获取您的 API 密钥
+   - 从[仪表板](https://sunra.ai/dashboard/api-tokens)获取您的 API 密钥
 
 3. 将您的 API 密钥设置为环境变量：
    ```bash
@@ -33,6 +33,7 @@
 - **`text-to-video.py`** - 文本到视频生成
 - **`image-to-video.py`** - 图像到视频转换
 - **`speech-to-text.py`** - 语音到文本转换
+- **`demo-llm.py`** - 使用自动或显式 Provider 路由的 LLM 对话补全
 
 ### 输入转换示例
 

--- a/examples/demo-python/demo-llm.py
+++ b/examples/demo-python/demo-llm.py
@@ -24,20 +24,21 @@ def main():
     try:
         print("Sending streaming chat completion request...")
 
-        # Make a streaming chat completion request
+        # Omit extra_body to use automatic provider routing.
         stream = client.chat.completions.create(
-            model="google/gemini-2.5-flash-lite",  # You can use any llm model available on Sunra
+            model="google/gemini-2.5-flash",
             messages=[
                 {
                   "role": "system",
-                  "content": "You are an expert in AIGC, you can help me optimize the prompt for better results, especially for text to image models. I will give you a prompt, you can help me optimize it."
+                  "content": "You are a helpful assistant."
                 },
                 {
                   "role": "user",
-                  "content": "the original prompt is: 'A scene from a high-quality animated film, like a work by Makoto Shinkai. In a deep midsummer forest, a train speeds down tracks showered in sunlight filtering through the trees (komorebi). The camera weaves through the trees, chasing the train to emphasize the sense of speed. A girl with her head out the window is bathed in the rapidly changing light and shadow, her hair fluttering in a wind that carries the scent of green. The trees in the background become a green afterimage, vividly highlighting her expression, full of liberation, from moment to moment. '"
+                  "content": "Explain provider routing in two short sentences."
                 }
             ],
-            stream=True
+            stream=True,
+            extra_body={"provider": {"only": ["google-vertexai"]}}
         )
 
         print("\n" + "="*50)

--- a/examples/demo-python/notebooks/README.md
+++ b/examples/demo-python/notebooks/README.md
@@ -74,7 +74,7 @@ Welcome to the Sunra AI Python SDK Jupyter Notebooks! This collection of interac
 
 3. **Get Your API Key**:
    - Sign up at [sunra.ai](https://sunra.ai)
-   - Get your API key from the [dashboard](https://sunra.ai/dashboard/keys)
+   - Get your API key from the [dashboard](https://sunra.ai/dashboard/api-tokens)
 
 4. **Set Up Environment Variable**:
    ```bash

--- a/examples/demo-python/notebooks/README.zh-CN.md
+++ b/examples/demo-python/notebooks/README.zh-CN.md
@@ -74,7 +74,7 @@
 
 3. **获取 API 密钥**：
    - 在 [sunra.ai](https://sunra.ai) 注册
-   - 从[仪表板](https://sunra.ai/dashboard/keys)获取 API 密钥
+   - 从[仪表板](https://sunra.ai/dashboard/api-tokens)获取 API 密钥
 
 4. **设置环境变量**：
    ```bash


### PR DESCRIPTION
## Summary
- show provider routing with the standard OpenAI SDK
- update runnable Node.js and Python LLM examples
- correct API-token dashboard links and LLM base URLs
- clarify that provider can be omitted for automatic routing

## Validation
- targeted TypeScript compile passed
- targeted ESLint passed (one existing HTTP_PROXY warning)
- Python example syntax check passed
- repository typecheck/lint passed after building local client packages
- full Java/Python hooks require unavailable global gradle/python executables

Linear: SUNRA-384