### PR TITLE
Use canonical GPT Image 2 endpoint in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ import sunra_client
 
 # Simple synchronous call
 result = sunra_client.subscribe(
-    "black-forest-labs/flux-kontext-pro/text-to-image",
-    arguments={"prompt": "a cute cat, realistic, orange"}
+    "openai/gpt-image-2/text-to-image",
+    arguments={"prompt": "a cute cat, realistic, orange", "quality": "high"}
 )
 print(result["images"][0]["url"])
 
 # Asynchronous call
 async def main():
     result = await sunra_client.subscribe_async(
-        "black-forest-labs/flux-kontext-pro/text-to-image",
-        arguments={"prompt": "a cute cat, realistic, orange"}
+        "openai/gpt-image-2/text-to-image",
+        arguments={"prompt": "a cute cat, realistic, orange", "quality": "high"}
     )
     print(result["images"][0]["url"])
 ```
@@ -71,10 +71,11 @@ const sunra = createSunraClient({
 });
 
 const result = await sunra.subscribe(
-  "black-forest-labs/flux-kontext-pro/text-to-image",
+  "openai/gpt-image-2/text-to-image",
   {
     input: {
-      prompt: "a cute cat, realistic, orange"
+      prompt: "a cute cat, realistic, orange",
+      quality: "high"
     }
   }
 );
@@ -89,9 +90,12 @@ import ai.sunra.client.*;
 var sunra = SunraClient.withEnvCredentials();
 
 var result = sunra.subscribe(
-    "black-forest-labs/flux-kontext-pro/text-to-image",
+    "openai/gpt-image-2/text-to-image",
     SubscribeOptions.<JsonObject>builder()
-        .input(Map.of("prompt", "a cute cat, realistic, orange"))
+        .input(Map.of(
+            "prompt", "a cute cat, realistic, orange",
+            "quality", "high"
+        ))
         .resultType(JsonObject.class)
         .build()
 );

--- a/README.md
+++ b/README.md
@@ -15,18 +15,21 @@ This repository contains the official client libraries for [sunra.ai](https://su
 ## Available Client Libraries
 
 ### 🐍 Python Client
+
 - **Location**: [`clients/python/`](./clients/python/)
 - **Package**: `sunra-client` (PyPI)
 - **Features**: Synchronous and asynchronous support, streaming responses, file uploads
 - **Installation**: `pip install sunra-client`
 
 ### 📦 JavaScript/TypeScript Client
+
 - **Location**: [`clients/javascript/`](./clients/javascript/)
 - **Package**: `@sunra/client` (npm)
 - **Features**: Works in Web, Node.js, and React Native environments
 - **Installation**: `npm install @sunra/client`
 
 ### ☕ Java Client
+
 - **Location**: [`clients/java/`](./clients/java/)
 - **Package**: `ai.sunra.client:sunra-client` (Maven Central)
 - **Features**: Synchronous, asynchronous, and Kotlin coroutine support
@@ -70,15 +73,12 @@ const sunra = createSunraClient({
   credentials: process.env.SUNRA_KEY,
 });
 
-const result = await sunra.subscribe(
-  "openai/gpt-image-2/text-to-image",
-  {
-    input: {
-      prompt: "a cute cat, realistic, orange",
-      quality: "high"
-    }
-  }
-);
+const result = await sunra.subscribe("openai/gpt-image-2/text-to-image", {
+  input: {
+    prompt: "a cute cat, realistic, orange",
+    quality: "high",
+  },
+});
 console.log(result.images[0].url);
 ```
 
@@ -115,6 +115,7 @@ For client-side applications, we provide a server proxy to securely handle API c
 The MCP server provides a universal interface for AI model tools, enabling seamless integration with modern code assistants and IDEs such as Cursor and Claude Desktop. It acts as a bridge between Sunra.ai and your development environment, exposing Sunra's models and tools via the [Model Context Protocol](https://github.com/modelcontextprotocol).
 
 **Why use the MCP server?**
+
 - Enables code assistants (like Cursor, Claude, etc.) to access Sunra models and tools directly from your editor
 - Supports listing models, fetching schemas, submitting jobs, streaming results, and more
 - Secure: API keys are managed via environment variables or runtime configuration
@@ -129,6 +130,7 @@ npx @sunra/mcp-server --transport http --port 3925
 ```
 
 #### 2. For Cursor IDE
+
 - Add to your `.cursor/mcp.json`:
 
 ```json
@@ -140,6 +142,7 @@ npx @sunra/mcp-server --transport http --port 3925
   }
 }
 ```
+
 - Set your API key:
   ```bash
   export SUNRA_KEY="your-api-key-here"
@@ -147,6 +150,7 @@ npx @sunra/mcp-server --transport http --port 3925
 - In Cursor, select the `sunra-mcp-server` and use tools like `list-models`, `model-schema`, etc.
 
 #### 3. For Claude Desktop (Anthropic)
+
 - Start the server in stdio mode (default):
   ```bash
   npx @sunra/mcp-server
@@ -161,6 +165,7 @@ npx @sunra/mcp-server --transport http --port 3925
 - In Claude, select the `sunra-mcp-server` and use the available tools.
 
 #### 4. Advanced Usage & Documentation
+
 - See [`mcp-server/README.md`](./mcp-server/README.md) for full tool list, development, and troubleshooting.
 
 ## Examples

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,18 +15,21 @@
 ## 可用的客户端库
 
 ### 🐍 Python 客户端
+
 - **位置**: [`clients/python/`](./clients/python/)
 - **包**: `sunra-client` (PyPI)
 - **特性**: 同步和异步支持、流式响应、文件上传
 - **安装**: `pip install sunra-client`
 
 ### 📦 JavaScript/TypeScript 客户端
+
 - **位置**: [`clients/javascript/`](./clients/javascript/)
 - **包**: `@sunra/client` (npm)
 - **特性**: 可在 Web、Node.js 和 React Native 环境中工作
 - **安装**: `npm install @sunra/client`
 
 ### ☕ Java 客户端
+
 - **位置**: [`clients/java/`](./clients/java/)
 - **包**: `ai.sunra.client:sunra-client` (Maven Central)
 - **特性**: 同步、异步和 Kotlin 协程支持
@@ -70,15 +73,12 @@ const sunra = createSunraClient({
   credentials: process.env.SUNRA_KEY,
 });
 
-const result = await sunra.subscribe(
-  "openai/gpt-image-2/text-to-image",
-  {
-    input: {
-      prompt: "a cute cat, realistic, orange",
-      quality: "high"
-    }
-  }
-);
+const result = await sunra.subscribe("openai/gpt-image-2/text-to-image", {
+  input: {
+    prompt: "a cute cat, realistic, orange",
+    quality: "high",
+  },
+});
 console.log(result.images[0].url);
 ```
 
@@ -115,6 +115,7 @@ System.out.println(result.getData());
 MCP 服务器为 AI 模型工具提供了一个通用接口，实现了与现代代码助手和 IDE（如 Cursor 和 Claude Desktop）的无缝集成。它充当 sunra.ai 和您的开发环境之间的桥梁，通过[模型上下文协议](https://github.com/modelcontextprotocol)暴露 Sunra 的模型和工具。
 
 **为什么要使用 MCP 服务器？**
+
 - 使代码助手（如 Cursor、Claude 等）能够直接从您的编辑器访问 Sunra 模型和工具
 - 支持列出模型、获取模式、提交作业、流式传输结果等
 - 安全：API 密钥通过环境变量或运行时配置进行管理
@@ -129,6 +130,7 @@ npx @sunra/mcp-server --transport http --port 3925
 ```
 
 #### 2. 对于 Cursor IDE
+
 - 添加到您的 `.cursor/mcp.json`:
 
 ```json
@@ -140,6 +142,7 @@ npx @sunra/mcp-server --transport http --port 3925
   }
 }
 ```
+
 - 设置您的 API 密钥:
   ```bash
   export SUNRA_KEY="your-api-key-here"
@@ -147,6 +150,7 @@ npx @sunra/mcp-server --transport http --port 3925
 - 在 Cursor 中，选择 `sunra-mcp-server` 并使用 `list-models`、`model-schema` 等工具。
 
 #### 3. 对于 Claude Desktop (Anthropic)
+
 - 在 stdio 模式下启动服务器（默认）：
   ```bash
   npx @sunra/mcp-server
@@ -161,6 +165,7 @@ npx @sunra/mcp-server --transport http --port 3925
 - 在 Claude 中，选择 `sunra-mcp-server` 并使用可用的工具。
 
 #### 4. 高级用法和文档
+
 - 有关完整的工具列表、开发和故障排除，请参阅 [`mcp-server/README.md`](./mcp-server/README.md)。
 
 ## 示例
@@ -211,4 +216,3 @@ npx @sunra/mcp-server --transport http --port 3925
 - [fal-ai/fal](https://github.com/fal-ai/fal/tree/main/projects/fal_client)
 
 并已适配以与 sunra.ai 协同工作。原始项目根据 MIT/Apache 2.0 许可证授权。我们对原始作者的贡献表示感谢。
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,16 +47,16 @@ import sunra_client
 
 # 简单同步调用
 result = sunra_client.subscribe(
-    "black-forest-labs/flux-kontext-pro/text-to-image",
-    arguments={"prompt": "a cute cat, realistic, orange"}
+    "openai/gpt-image-2/text-to-image",
+    arguments={"prompt": "a cute cat, realistic, orange", "quality": "high"}
 )
 print(result["images"][0]["url"])
 
 # 异步调用
 async def main():
     result = await sunra_client.subscribe_async(
-        "black-forest-labs/flux-kontext-pro/text-to-image",
-        arguments={"prompt": "a cute cat, realistic, orange"}
+        "openai/gpt-image-2/text-to-image",
+        arguments={"prompt": "a cute cat, realistic, orange", "quality": "high"}
     )
     print(result["images"][0]["url"])
 ```
@@ -71,10 +71,11 @@ const sunra = createSunraClient({
 });
 
 const result = await sunra.subscribe(
-  "black-forest-labs/flux-kontext-pro/text-to-image",
+  "openai/gpt-image-2/text-to-image",
   {
     input: {
-      prompt: "a cute cat, realistic, orange"
+      prompt: "a cute cat, realistic, orange",
+      quality: "high"
     }
   }
 );
@@ -89,9 +90,12 @@ import ai.sunra.client.*;
 var sunra = SunraClient.withEnvCredentials();
 
 var result = sunra.subscribe(
-    "black-forest-labs/flux-kontext-pro/text-to-image",
+    "openai/gpt-image-2/text-to-image",
     SubscribeOptions.<JsonObject>builder()
-        .input(Map.of("prompt", "a cute cat, realistic, orange"))
+        .input(Map.of(
+            "prompt", "a cute cat, realistic, orange",
+            "quality", "high"
+        ))
         .resultType(JsonObject.class)
         .build()
 );

--- a/examples/demo-nodejs/src/text-to-image.ts
+++ b/examples/demo-nodejs/src/text-to-image.ts
@@ -17,14 +17,11 @@ const main = async () => {
     console.log(chalk.green('Subscribing to the queue...'))
 
     // find more models here: https://sunra.ai/models
-    const result = await sunra.subscribe('black-forest-labs/flux-kontext-pro/text-to-image', {
+    const result = await sunra.subscribe('openai/gpt-image-2/text-to-image', {
       input: {
         prompt: 'a bedroom with messy goods on the bed and floor',
-        prompt_enhancer: false,
-        seed: 0,
-        aspect_ratio: '16:9',
+        quality: 'high',
         output_format: 'jpeg',
-        safety_tolerance: 6
       },
       logs: true,
       onEnqueue: (requestId) => {

--- a/examples/demo-nodejs/src/text-to-image.ts
+++ b/examples/demo-nodejs/src/text-to-image.ts
@@ -1,10 +1,10 @@
-import { sunra } from '@sunra/client'
-import chalk from 'chalk'
+import { sunra } from "@sunra/client";
+import chalk from "chalk";
 
-const apiKey = process.env.SUNRA_KEY || ''
+const apiKey = process.env.SUNRA_KEY || "";
 if (!apiKey) {
-  console.error(chalk.red('SUNRA_KEY is not set'))
-  process.exit(1)
+  console.error(chalk.red("SUNRA_KEY is not set"));
+  process.exit(1);
 }
 
 // sunra reads the credentials from the environment variable SUNRA_KEY by default, you can also set the credentials in the config
@@ -14,35 +14,35 @@ if (!apiKey) {
 
 const main = async () => {
   try {
-    console.log(chalk.green('Subscribing to the queue...'))
+    console.log(chalk.green("Subscribing to the queue..."));
 
     // find more models here: https://sunra.ai/models
-    const result = await sunra.subscribe('openai/gpt-image-2/text-to-image', {
+    const result = await sunra.subscribe("openai/gpt-image-2/text-to-image", {
       input: {
-        prompt: 'a bedroom with messy goods on the bed and floor',
-        quality: 'high',
-        output_format: 'jpeg',
+        prompt: "a bedroom with messy goods on the bed and floor",
+        quality: "high",
+        output_format: "jpeg",
       },
       logs: true,
       onEnqueue: (requestId) => {
-        console.log(chalk.green('Enqueued:'), requestId)
+        console.log(chalk.green("Enqueued:"), requestId);
       },
       onQueueUpdate: (status) => {
-        console.log(chalk.green('Queue update:'), status)
+        console.log(chalk.green("Queue update:"), status);
       },
-    })
-    console.log(result)
+    });
+    console.log(result);
   } catch (error) {
-    const data = (error as any).response?.data
+    const data = (error as any).response?.data;
     // check if this is an axios error
     if (data) {
-      console.error(chalk.red('Error:'), data)
+      console.error(chalk.red("Error:"), data);
     } else {
-      console.error(chalk.red('Error:'), error)
+      console.error(chalk.red("Error:"), error);
     }
 
-    process.exit(1)
+    process.exit(1);
   }
-}
+};
 
-main().catch(console.error)
+main().catch(console.error);

--- a/examples/demo-python/text-to-image.py
+++ b/examples/demo-python/text-to-image.py
@@ -4,14 +4,11 @@ import sunra_client
 
 # find more models here: https://sunra.ai/models
 result = sunra_client.subscribe(
-    "black-forest-labs/flux-kontext-pro/text-to-image",
+    "openai/gpt-image-2/text-to-image",
     arguments={
         "prompt": "a bedroom with messy goods on the bed and floor",
-        "prompt_enhancer": False,
-        "seed": 0,
-        "aspect_ratio": "16:9",
+        "quality": "high",
         "output_format": "jpeg",
-        "safety_tolerance": 6
     },
     with_logs=True,
     on_enqueue=print,


### PR DESCRIPTION
## Summary
- update Node.js and Python image examples to use the canonical OpenAI GPT Image 2 model and endpoint
- align English and Chinese README examples
- format example code

## Release
Merged to dev for normal branch continuity. Production main receives the same two commits through a separate canonical-only hotfix so unrelated branch divergence is not included.