### PR TITLE
Support async media provider preferences in SDKs

### DIFF
--- a/.changeset/media-provider-routing.md
+++ b/.changeset/media-provider-routing.md
@@ -1,0 +1,7 @@
+---
+"@sunra/client": minor
+"sunra_client": minor
+"ai.sunra.client:sunra-client": minor
+---
+
+Add optional provider routing preferences to asynchronous queue submit and subscribe calls.

--- a/clients/java/client-async/src/main/java/ai/sunra/client/AsyncSunraClientImpl.java
+++ b/clients/java/client-async/src/main/java/ai/sunra/client/AsyncSunraClientImpl.java
@@ -28,6 +28,7 @@ public class AsyncSunraClientImpl implements AsyncSunraClient {
                         QueueSubmitOptions.builder()
                                 .input(options.getInput())
                                 .webhookUrl(options.getWebhookUrl())
+                                .provider(options.getProvider())
                                 .build())
                 .thenCompose((submitted) -> queueClient.subscribeToStatus(
                         QueueSubscribeOptions.builder()

--- a/clients/java/client-kotlin/bin/main/QueueClient.kt
+++ b/clients/java/client-kotlin/bin/main/QueueClient.kt
@@ -12,6 +12,7 @@ import ai.sunra.client.queue.QueueSubscribeOptions as InternalSubscribeOptions
 
 data class SubmitOptions(
     val webhookUrl: String? = null,
+    val provider: Map<String, Any>? = null,
 )
 
 data class StatusOptions(
@@ -106,6 +107,7 @@ internal class QueueClientImpl(
             InternalSubmitOptions.builder()
                 .input(input)
                 .webhookUrl(options.webhookUrl)
+                .provider(options.provider)
                 .build(),
         ).await()
     }

--- a/clients/java/client-kotlin/bin/main/SunraClient.kt
+++ b/clients/java/client-kotlin/bin/main/SunraClient.kt
@@ -17,6 +17,7 @@ data class RunOptions(
 data class SubscribeOptions(
     val logs: Boolean = false,
     val webhookUrl: String? = null,
+    val provider: Map<String, Any>? = null,
 )
 
 /**
@@ -83,6 +84,7 @@ internal class SunraClientKotlinImpl(
                 .input(input)
                 .resultType(resultType.java)
                 .logs(options.logs)
+                .provider(options.provider)
                 .onQueueUpdate(onQueueUpdate)
                 .build()
         return client.subscribe(endpointId, internalOptions).thenConvertOutput().await()

--- a/clients/java/client-kotlin/src/main/kotlin/QueueClient.kt
+++ b/clients/java/client-kotlin/src/main/kotlin/QueueClient.kt
@@ -12,6 +12,7 @@ import ai.sunra.client.queue.QueueSubscribeOptions as InternalSubscribeOptions
 
 data class SubmitOptions(
     val webhookUrl: String? = null,
+    val provider: Map<String, Any>? = null,
 )
 
 data class StatusOptions(
@@ -106,6 +107,7 @@ internal class QueueClientImpl(
             InternalSubmitOptions.builder()
                 .input(input)
                 .webhookUrl(options.webhookUrl)
+                .provider(options.provider)
                 .build(),
         ).await()
     }

--- a/clients/java/client-kotlin/src/main/kotlin/SunraClient.kt
+++ b/clients/java/client-kotlin/src/main/kotlin/SunraClient.kt
@@ -17,6 +17,7 @@ data class RunOptions(
 data class SubscribeOptions(
     val logs: Boolean = false,
     val webhookUrl: String? = null,
+    val provider: Map<String, Any>? = null,
 )
 
 /**
@@ -83,6 +84,7 @@ internal class SunraClientKotlinImpl(
                 .input(input)
                 .resultType(resultType.java)
                 .logs(options.logs)
+                .provider(options.provider)
                 .onQueueUpdate(onQueueUpdate)
                 .build()
         return client.subscribe(endpointId, internalOptions).thenConvertOutput().await()

--- a/clients/java/client/src/main/java/ai/sunra/client/SubscribeOptions.java
+++ b/clients/java/client/src/main/java/ai/sunra/client/SubscribeOptions.java
@@ -5,6 +5,7 @@ import ai.sunra.client.queue.QueueStatus;
 import com.google.gson.JsonObject;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.Map;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.Data;
@@ -24,6 +25,12 @@ public class SubscribeOptions<O> implements ApiOptions<O> {
      */
     @Nullable
     private final String webhookUrl;
+
+    /**
+     * Optional provider routing preferences.
+     */
+    @Nullable
+    private final Map<String, Object> provider;
 
     /**
      * The result type.

--- a/clients/java/client/src/main/java/ai/sunra/client/SunraClientImpl.java
+++ b/clients/java/client/src/main/java/ai/sunra/client/SunraClientImpl.java
@@ -54,6 +54,7 @@ public class SunraClientImpl implements SunraClient {
                     QueueSubmitOptions.builder()
                             .input(options.getInput())
                             .webhookUrl(options.getWebhookUrl())
+                            .provider(options.getProvider())
                             .build());
 
             final var completed = queueClient.subscribeToStatus(

--- a/clients/java/client/src/main/java/ai/sunra/client/queue/QueueSubmitOptions.java
+++ b/clients/java/client/src/main/java/ai/sunra/client/queue/QueueSubmitOptions.java
@@ -5,6 +5,10 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
+import java.util.Map;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 @Data
 @Builder
@@ -16,12 +20,28 @@ public class QueueSubmitOptions implements ApiOptions<QueueStatus.InQueue> {
     @Nullable
     private final String webhookUrl;
 
+    @Nullable
+    private final Map<String, Object> provider;
+
     @Nonnull
     private final Class<QueueStatus.InQueue> resultType = QueueStatus.InQueue.class;
 
     @Override
     public String getHttpMethod() {
         return "POST";
+    }
+
+    @Override
+    public Object getInput() {
+        if (provider == null) {
+            return input;
+        }
+        final JsonElement serializedInput = new Gson().toJsonTree(input);
+        final JsonObject body = serializedInput != null && serializedInput.isJsonObject()
+                ? serializedInput.getAsJsonObject()
+                : new JsonObject();
+        body.add("provider", new Gson().toJsonTree(provider));
+        return body;
     }
 
     public static QueueSubmitOptions withInput(@Nonnull Object input) {

--- a/clients/java/client/src/test/java/ai/sunra/client/queue/QueueSubmitOptionsTest.java
+++ b/clients/java/client/src/test/java/ai/sunra/client/queue/QueueSubmitOptionsTest.java
@@ -1,0 +1,35 @@
+package ai.sunra.client.queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.gson.JsonObject;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class QueueSubmitOptionsTest {
+
+    @Test
+    void addsProviderRoutingToTheCanonicalRequestBody() {
+        var options = QueueSubmitOptions.builder()
+                .input(Map.of("prompt", "sunrise"))
+                .provider(Map.of("only", List.of("fal")))
+                .build();
+
+        var body = (JsonObject) options.getInput();
+
+        assertEquals("sunrise", body.get("prompt").getAsString());
+        assertEquals("fal", body.getAsJsonObject("provider")
+                .getAsJsonArray("only")
+                .get(0)
+                .getAsString());
+    }
+
+    @Test
+    void leavesAutomaticRequestsUnchanged() {
+        var input = Map.of("prompt", "sunrise");
+        var options = QueueSubmitOptions.builder().input(input).build();
+
+        assertEquals(input, options.getInput());
+    }
+}

--- a/clients/javascript/src/queue.spec.ts
+++ b/clients/javascript/src/queue.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createConfig } from './config'
+import { SunraQueueClientImpl } from './queue'
+
+describe('SunraQueueClientImpl provider routing', () => {
+  it('writes provider preferences into the canonical request body and compatibility header', async () => {
+    const request = vi.fn().mockResolvedValue({
+      data: { status: 'IN_QUEUE', request_id: 'pd_test' },
+    })
+    const client = new SunraQueueClientImpl(
+      () => createConfig({
+        credentials: 'key_test',
+        axios: { request } as any,
+      }),
+      {
+        transformInput: vi.fn(async input => input),
+      } as any,
+    )
+
+    await client.submit('google/gemini-2.5-flash-image/text-to-image', {
+      input: { prompt: 'sunrise' },
+      provider: { only: ['fal'] },
+    })
+
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      data: {
+        prompt: 'sunrise',
+        provider: { only: ['fal'] },
+      },
+      headers: expect.objectContaining({
+        'x-provider-settings': JSON.stringify({ only: ['fal'] }),
+      }),
+    }))
+  })
+
+  it('does not add provider routing fields when automatic routing is used', async () => {
+    const request = vi.fn().mockResolvedValue({
+      data: { status: 'IN_QUEUE', request_id: 'pd_test' },
+    })
+    const client = new SunraQueueClientImpl(
+      () => createConfig({
+        credentials: 'key_test',
+        axios: { request } as any,
+      }),
+      {
+        transformInput: vi.fn(async input => input),
+      } as any,
+    )
+
+    await client.submit('google/gemini-2.5-flash-image/text-to-image', {
+      input: { prompt: 'sunrise' },
+    })
+
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      data: { prompt: 'sunrise' },
+    }))
+    expect(request.mock.calls[0][0].headers).not.toHaveProperty(
+      'x-provider-settings',
+    )
+  })
+})

--- a/clients/javascript/src/queue.ts
+++ b/clients/javascript/src/queue.ts
@@ -203,13 +203,16 @@ export class SunraQueueClientImpl implements SunraQueueClient {
       : undefined
 
     const provider = options?.provider
+    const requestInput = provider && input && typeof input === 'object'
+      ? { ...(input as Record<string, unknown>), provider }
+      : input
 
     const baseUrl = `${getRestApiUrl()}/queue/${endpointId}`
     const search = webhookUrl ? `?webhook=${webhookUrl}` : ''
     const url = `${baseUrl}${search}`
     return dispatchRequest<Input, SunraInQueueQueueStatus>({
       targetUrl: url,
-      input: input as Input,
+      input: requestInput as Input,
       config: this.config,
       headers: provider ? {
         'x-provider-settings': JSON.stringify(provider)

--- a/clients/javascript/src/types.ts
+++ b/clients/javascript/src/types.ts
@@ -27,9 +27,8 @@ export type SunraRunOptions<Input> = {
   readonly onError?: (error: SunraError) => void;
 
   /**
-   * Optional provider configuration.
-   *
-   * @experimental this is a experimental feature
+   * Optional provider routing preferences. Use `{ only: ['provider-id'] }`
+   * to require one provider. Omit this field for automatic routing.
    */
   provider?: SunraProviderConfig;
 };
@@ -107,4 +106,6 @@ export interface SunraProviderConfig {
   allow_fallbacks?: boolean
   sort?: 'price' | 'latency' | 'throughput'
   order?: string[]
+  only?: string[]
+  ignore?: string[]
 }

--- a/clients/python/src/sunra_client/client.py
+++ b/clients/python/src/sunra_client/client.py
@@ -559,6 +559,7 @@ class AsyncClient:
         path: str = "",
         webhook_url: str | None = None,
         with_logs: bool = True,
+        provider: dict[str, Any] | None = None,
     ) -> AsyncRequestHandle:
         """Submit an application with the given arguments (which will be JSON serialized).
 
@@ -568,6 +569,11 @@ class AsyncClient:
 
         # Transform input to upload files automatically
         transformed_arguments = await self.transform_input(arguments)
+        if provider is not None:
+            transformed_arguments = {
+                **transformed_arguments,
+                "provider": provider,
+            }
 
         url = QUEUE_URL_FORMAT + application
         if path:
@@ -609,6 +615,7 @@ class AsyncClient:
         with_logs: bool = True,
         on_queue_update: Callable[[Status], None] | None = None,
         on_error: Callable[[SunraClientError], None] | None = None,
+        provider: dict[str, Any] | None = None,
     ) -> AnyJSON | None:
         try:
             handle = await self.submit(
@@ -616,6 +623,7 @@ class AsyncClient:
                 arguments,
                 path=path,
                 with_logs=with_logs,
+                provider=provider,
             )
 
             if on_enqueue is not None:
@@ -865,6 +873,7 @@ class SyncClient:
         path: str = "",
         webhook_url: str | None = None,
         with_logs: bool = True,
+        provider: dict[str, Any] | None = None,
     ) -> SyncRequestHandle:
         """Submit an application with the given arguments (which will be JSON serialized).
 
@@ -874,6 +883,11 @@ class SyncClient:
 
         # Transform input to upload files automatically
         transformed_arguments = self.transform_input(arguments)
+        if provider is not None:
+            transformed_arguments = {
+                **transformed_arguments,
+                "provider": provider,
+            }
 
         url = QUEUE_URL_FORMAT + application
         if path:
@@ -915,6 +929,7 @@ class SyncClient:
         with_logs: bool = True,
         on_queue_update: Callable[[Status], None] | None = None,
         on_error: Callable[[SunraClientError], None] | None = None,
+        provider: dict[str, Any] | None = None,
     ) -> AnyJSON | None:
         try:
             handle = self.submit(
@@ -922,6 +937,7 @@ class SyncClient:
                 arguments,
                 path=path,
                 with_logs=with_logs,
+                provider=provider,
             )
 
             if on_enqueue is not None:

--- a/clients/python/tests/unit/test_client.py
+++ b/clients/python/tests/unit/test_client.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import sunra_client
 from sunra_client.auth import _global_config, MissingCredentialsError
@@ -123,6 +123,35 @@ def test_sync_submit_writes_provider_into_canonical_request_body():
         patch("sunra_client.client._raise_for_status"),
     ):
         client.submit(
+            "google/gemini-2.5-flash-image/text-to-image",
+            {"prompt": "sunrise"},
+            provider={"only": ["fal"]},
+        )
+
+    assert request.call_args.kwargs["json"] == {
+        "prompt": "sunrise",
+        "provider": {"only": ["fal"]},
+    }
+
+
+async def test_async_submit_writes_provider_into_canonical_request_body():
+    client = sunra_client.AsyncClient(key="test-key")
+    response = Mock()
+    response.json.return_value = {
+        "request_id": "req_test",
+        "response_url": "/requests/req_test",
+        "status_url": "/requests/req_test/status",
+        "cancel_url": "/requests/req_test/cancel",
+    }
+
+    with (
+        patch(
+            "sunra_client.client._async_maybe_retry_request",
+            new=AsyncMock(return_value=response),
+        ) as request,
+        patch("sunra_client.client._raise_for_status"),
+    ):
+        await client.submit(
             "google/gemini-2.5-flash-image/text-to-image",
             {"prompt": "sunrise"},
             provider={"only": ["fal"]},

--- a/clients/python/tests/unit/test_client.py
+++ b/clients/python/tests/unit/test_client.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import sunra_client
 from sunra_client.auth import _global_config, MissingCredentialsError
@@ -106,3 +106,29 @@ def test_client_explicit_key_overrides_global():
 
     # Clean up
     _global_config._credentials = None
+
+
+def test_sync_submit_writes_provider_into_canonical_request_body():
+    client = sunra_client.SyncClient(key="test-key")
+    response = Mock()
+    response.json.return_value = {
+        "request_id": "req_test",
+        "response_url": "/requests/req_test",
+        "status_url": "/requests/req_test/status",
+        "cancel_url": "/requests/req_test/cancel",
+    }
+
+    with (
+        patch("sunra_client.client._maybe_retry_request", return_value=response) as request,
+        patch("sunra_client.client._raise_for_status"),
+    ):
+        client.submit(
+            "google/gemini-2.5-flash-image/text-to-image",
+            {"prompt": "sunrise"},
+            provider={"only": ["fal"]},
+        )
+
+    assert request.call_args.kwargs["json"] == {
+        "prompt": "sunrise",
+        "provider": {"only": ["fal"]},
+    }


### PR DESCRIPTION
## What changed

- Add optional provider preferences to JavaScript, Python sync/async, Java, and Kotlin queue submit/subscribe APIs.
- Send provider routing in the canonical request body, retaining the JavaScript compatibility header.
- Add minor changesets for the JavaScript, Python, and Java artifacts.

## Why

SDK callers need the same `provider.only` and Automatic omission semantics as the canonical HTTP API and Playground examples.

## Validation

- JavaScript queue tests and type/build checks passed.
- Python client tests: 7 passed; compile checks passed.
- Java/Kotlin targeted Gradle tests and classes passed with JDK 17.
- Changeset status recognizes all three SDK artifacts.

## Coordination

Part of the cross-repository async media provider-routing rollout. The API PR must deploy before publishing SDK releases.
